### PR TITLE
espelhei as GPIO corrigi o controle do PWM

### DIFF
--- a/Microcontroller/platformio.ini
+++ b/Microcontroller/platformio.ini
@@ -14,6 +14,7 @@ board = esp32-c3-devkitm-1
 framework = arduino
 board_build.mcu = esp32c3
 board_build.f_cpu = 160000000L
+upload_protocol = esptool
 build_flags = 
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1

--- a/Microcontroller/src/main.cpp
+++ b/Microcontroller/src/main.cpp
@@ -108,7 +108,7 @@ class ServerCallback : public NimBLEServerCallbacks {
   }
 
   void onDisconnect(NimBLEServer *pServer) {
-    ControlWheels(wheels, 0, 0, 0);
+    ControlWheels(wheels, 0, 0, 0); // Stop Car
     Serial.println("Client Disconnected");
 
     digitalWrite(LED, HIGH);
@@ -163,7 +163,7 @@ class ControlCarCallback : public NimBLECharacteristicCallbacks {
         digitalRead(wheels.rearLeft.dirPin) ? "HIGH" : "LOW");
     Serial.printf(
         "RR: PWMpin = %d; Duty cycle: %u; DIRpin = %d; level = %s\n\r",
-        wheels.rearRight.pwmPin, ledcRead(wheels.frontLeft.pwmChan),
+        wheels.rearRight.pwmPin, ledcRead(wheels.rearRight.pwmChan),
         wheels.rearRight.dirPin,
         digitalRead(wheels.rearRight.dirPin) ? "HIGH" : "LOW");
   }

--- a/Microcontroller/src/main.cpp
+++ b/Microcontroller/src/main.cpp
@@ -1,6 +1,7 @@
 #include "NimBLEDevice.h"
 #include <Arduino.h>
-// Defining the pins to control the wheels
+
+// Defining the pins and channels to control the wheels
 
 // Front Left wheel
 const uint8_t WHEEL_FL_PWM = 4;
@@ -75,8 +76,8 @@ void ControlWheel(Wheel wheel, float_t speed) {
 
   // convert float [0, 1] to uint16_t
   uint16_t pwmValue = (uint16_t)(speed * 1023.0f);
+  // Define PWM on channel
   ledcWrite(wheel.pwmChan, pwmValue);
-  uint32_t readDuty = ledcRead(wheel.pwmChan);
 }
 
 /**
@@ -140,15 +141,31 @@ class ControlCarCallback : public NimBLECharacteristicCallbacks {
   }
 
   /**
-   * @brief Read value of Duty cycle.
+   * @brief Read value state of wheels.
    *
    * @param chr
    */
   void onRead(NimBLECharacteristic *chr) {
-    Serial.printf("FL: %u ", ledcRead(wheels.frontLeft.pwmChan));
-    Serial.printf("FR: %u ", ledcRead(wheels.frontRight.pwmChan));
-    Serial.printf("RL: %u ", ledcRead(wheels.rearLeft.pwmChan));
-    Serial.printf("RR: %u\n\r", ledcRead(wheels.rearRight.pwmChan));
+    Serial.printf(
+        "FL: PWMpin = %d; Duty cycle: %u; DIRpin = %d; level = %s\n\r",
+        wheels.frontLeft.pwmPin, ledcRead(wheels.frontLeft.pwmChan),
+        wheels.frontLeft.dirPin,
+        digitalRead(wheels.frontLeft.dirPin) ? "HIGH" : "LOW");
+    Serial.printf(
+        "FR: PWMpin = %d; Duty cycle: %u; DIRpin = %d; level = %s\n\r",
+        wheels.frontRight.pwmPin, ledcRead(wheels.frontRight.pwmChan),
+        wheels.frontRight.dirPin,
+        digitalRead(wheels.frontRight.dirPin) ? "HIGH" : "LOW");
+    Serial.printf(
+        "RL: PWMpin = %d; Duty cycle: %u; DIRpin = %d; level = %s\n\r",
+        wheels.rearLeft.pwmPin, ledcRead(wheels.rearLeft.pwmChan),
+        wheels.rearLeft.dirPin,
+        digitalRead(wheels.rearLeft.dirPin) ? "HIGH" : "LOW");
+    Serial.printf(
+        "RR: PWMpin = %d; Duty cycle: %u; DIRpin = %d; level = %s\n\r",
+        wheels.rearRight.pwmPin, ledcRead(wheels.frontLeft.pwmChan),
+        wheels.rearRight.dirPin,
+        digitalRead(wheels.rearRight.dirPin) ? "HIGH" : "LOW");
   }
 };
 
@@ -172,6 +189,12 @@ void setup() {
   // Turn off led
   pinMode(LED, OUTPUT);
   digitalWrite(LED, HIGH);
+
+  // Set direction pin
+  pinMode(WHEEL_FL_DIR, OUTPUT);
+  pinMode(WHEEL_FR_DIR, OUTPUT);
+  pinMode(WHEEL_RL_DIR, OUTPUT);
+  pinMode(WHEEL_RR_DIR, OUTPUT);
 
   // Set resolution and frequency to wheel's PWM
   ledcSetup(WHEEL_FL_CHAN, PWM_FREQ, PWM_RESOLUTION);

--- a/Microcontroller/src/main.cpp
+++ b/Microcontroller/src/main.cpp
@@ -1,4 +1,3 @@
-#include "NimBLECharacteristic.h"
 #include "NimBLEDevice.h"
 #include <Arduino.h>
 // Defining the pins to control the wheels
@@ -31,9 +30,8 @@ const uint8_t BUZZER_RESOLUTION = 8; // Resolução do buzzer
 
 // UUIDs
 const char *SERVICE_UUID = "014dd1c0-9dde-4907-8c31-e7d6b7a77ddb";
-const char *CHARACTERISTIC_CONTROL_UUID =
-    "c7be25a0-d82d-44e0-8155-3cbac410e2ed";
-const char *CHARACTERISTIC_BUZZER_UUID = "1e29d664-837a-42cd-8051-451e8985c08b";
+const char *CHARACTERISTIC_CON_UUID = "c7be25a0-d82d-44e0-8155-3cbac410e2ed";
+const char *CHARACTERISTIC_BUZ_UUID = "1e29d664-837a-42cd-8051-451e8985c08b";
 const char *ADVERTISE_UUID = "1a995753-23ae-43da-95ce-5372236406ed";
 
 // Wheel infos
@@ -69,6 +67,7 @@ float speed_x, speed_y, speed_r = 0;
 void ControlWheel(Wheel wheel, float_t speed) {
   if (speed > 0) {
     digitalWrite(wheel.dirPin, HIGH);
+    speed = 1 - speed; // invert Duty cycle
   } else {
     digitalWrite(wheel.dirPin, LOW);
     speed = -speed;
@@ -206,12 +205,11 @@ void setup() {
   NimBLEService *pService = pServer->createService(SERVICE_UUID);
   // Create and set Callback to control direction and rotation of car
   NimBLECharacteristic *pCharacteristicCar = pService->createCharacteristic(
-      CHARACTERISTIC_CONTROL_UUID,
-      NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE);
+      CHARACTERISTIC_CON_UUID, NIMBLE_PROPERTY::READ | NIMBLE_PROPERTY::WRITE);
   pCharacteristicCar->setCallbacks(new ControlCarCallback());
   // Create and set Callback to control Buzzer of car
   NimBLECharacteristic *pCharacteristicBuz = pService->createCharacteristic(
-      CHARACTERISTIC_BUZZER_UUID, NIMBLE_PROPERTY::WRITE);
+      CHARACTERISTIC_BUZ_UUID, NIMBLE_PROPERTY::WRITE);
   pCharacteristicBuz->setCallbacks(new ControlCarBuzCallback());
 
   // Start service

--- a/Microcontroller/src/main.cpp
+++ b/Microcontroller/src/main.cpp
@@ -1,5 +1,7 @@
 #include "NimBLEDevice.h"
+#include "esp32-hal-ledc.h"
 #include <Arduino.h>
+#include <sys/_stdint.h>
 
 // Defining the pins and channels to control the wheels
 
@@ -101,8 +103,13 @@ class ServerCallback : public NimBLEServerCallbacks {
     Serial.println("Client Connected");
 
     digitalWrite(LED, LOW);
-
-    // Buzzer Sinalize
+    ledcWriteNote(4, NOTE_C, 4);
+    delay(200);
+    ledcWriteNote(4, NOTE_E, 4);
+    delay(200);
+    ledcWriteNote(4, NOTE_G, 4);
+    delay(200);
+    ledcWrite(4, 0);
 
     pServer->startAdvertising();
   }
@@ -113,7 +120,17 @@ class ServerCallback : public NimBLEServerCallbacks {
 
     digitalWrite(LED, HIGH);
 
-    // Buzzer Sinalize
+    ledcWriteNote(4, NOTE_G, 4);
+    delay(150);
+    ledcWriteNote(4, NOTE_E, 4);
+    delay(150);
+    ledcWriteNote(4, NOTE_C, 4);
+    delay(150);
+    ledcWrite(4, 0);
+
+    ledcWriteNote(4, NOTE_C, 4);
+    delay(500);
+    ledcWrite(4, 0);
 
     pServer->startAdvertising();
   }


### PR DESCRIPTION
Eu e o @luiz-iq ajustamos corretamente os pinos na montagem da PCB e configurei o PWM para controlar os motores. No caso do `arduino-esp32`, é importante inserir um `delay()` dentro do loop principal para garantir que outras tarefas tenham espaço para serem executadas corretamente.